### PR TITLE
Renaming 'Resources' into 'GameResources'

### DIFF
--- a/StarCraft2/GameResources.cpp
+++ b/StarCraft2/GameResources.cpp
@@ -1,31 +1,31 @@
 #include <iostream>
-#include "Resources.hpp"
+#include "GameResources.hpp"
 
-int Resources::totalQuantity = 0;
-int Resources::resourcesCollectedEachTime = 3;
+int GameResources::totalQuantity = 0;
+int GameResources::resourcesCollectedEachTime = 3;
 
-Resources::Resources(int initialQuantity)
+GameResources::GameResources(int initialQuantity)
 {
     totalQuantity = initialQuantity;
     std::cout << "========== There is a total of " << totalQuantity << " resources you can collect for the entire game ==========\n\n" << std::endl;
 }
 
-int Resources::GetQuantity()
+int GameResources::GetQuantity()
 {
     return totalQuantity;
 }
 
-int Resources::GetResourcesCollectedEachTime()
+int GameResources::GetResourcesCollectedEachTime()
 {
     return resourcesCollectedEachTime;
 }
 
-void Resources::AddQuantity(int amount)
+void GameResources::AddQuantity(int amount)
 {
     totalQuantity += amount;
 }
 
-void Resources::SubtractQuantity(int amount)
+void GameResources::SubtractQuantity(int amount)
 {
     totalQuantity = std::max(0, totalQuantity - amount);
 }

--- a/StarCraft2/GameResources.hpp
+++ b/StarCraft2/GameResources.hpp
@@ -1,14 +1,14 @@
 #pragma once
 #include <string>
 
-class Resources
+class GameResources
 {
 private:
 	static int totalQuantity;
 	static int resourcesCollectedEachTime;
 
 public:
-	Resources(int initialQuantity);
+	GameResources(int initialQuantity);
 	static int GetQuantity();
 	static int GetResourcesCollectedEachTime();
 	static void AddQuantity(int amount);

--- a/StarCraft2/StarCraft2.cpp
+++ b/StarCraft2/StarCraft2.cpp
@@ -5,7 +5,7 @@
 #include "Barrack.hpp"
 #include "Building.hpp"
 #include "Incubator.hpp"
-#include "Resources.hpp"
+#include "GameResources.hpp"
 #include "Soldier.hpp"
 #include "Worker.hpp"
 #include "FactionResourcesManager.hpp"
@@ -34,7 +34,7 @@ int main()
 
 
     // Initialize start of the game
-    Resources resources(100);
+    GameResources resources(100);
     FactionResourcesManager FRM;
     Incubator incubator;
     incubators.push_back(incubator);
@@ -44,7 +44,7 @@ int main()
     while (resources.GetQuantity() > 0 || FRM.GetTotalCollectedResources() <= 0)
     {
         // Total resources remaining in the game
-        std::cout << "Total resources remaining to be collected : " << Resources::GetQuantity() << std::endl;
+        std::cout << "Total resources remaining to be collected : " << GameResources::GetQuantity() << std::endl;
         // Number of resources
         std::cout << "Remaining resources: " << FRM.GetTotalCollectedResources() << std::endl;
         // Number of buildings and unit created

--- a/StarCraft2/StarCraft2.vcxproj
+++ b/StarCraft2/StarCraft2.vcxproj
@@ -135,7 +135,7 @@
     <ClCompile Include="Barrack.cpp" />
     <ClCompile Include="Building.cpp" />
     <ClCompile Include="Incubator.cpp" />
-    <ClCompile Include="Resources.cpp" />
+    <ClCompile Include="GameResources.cpp" />
     <ClCompile Include="Soldier.cpp" />
     <ClCompile Include="StarCraft2.cpp" />
     <ClCompile Include="Unit.cpp" />
@@ -146,7 +146,7 @@
     <ClInclude Include="Barrack.hpp" />
     <ClInclude Include="Building.hpp" />
     <ClInclude Include="Incubator.hpp" />
-    <ClInclude Include="Resources.hpp" />
+    <ClInclude Include="GameResources.hpp" />
     <ClInclude Include="Soldier.hpp" />
     <ClInclude Include="Unit.hpp" />
     <ClInclude Include="Worker.hpp" />

--- a/StarCraft2/StarCraft2.vcxproj.filters
+++ b/StarCraft2/StarCraft2.vcxproj.filters
@@ -19,17 +19,11 @@
     <Filter Include="Source Files\Unit">
       <UniqueIdentifier>{412fd492-75fe-4a3b-b966-5e6ee0529486}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\Management">
-      <UniqueIdentifier>{b35cd1cd-0b9a-4a9c-a2b8-46d7852ef909}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\Resources">
       <UniqueIdentifier>{b55cc004-8880-4d23-8112-c0d09ce30afe}</UniqueIdentifier>
     </Filter>
     <Filter Include="Header Files\Base Classes">
       <UniqueIdentifier>{2bbc9f1e-cf09-44ee-bdaf-776c223d0400}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Header Files\Management">
-      <UniqueIdentifier>{2501693d-fa09-44da-baff-2c7320099aa6}</UniqueIdentifier>
     </Filter>
     <Filter Include="Header Files\Resources">
       <UniqueIdentifier>{2bc01627-e151-4205-9c65-a5c8df41fdb7}</UniqueIdentifier>
@@ -60,10 +54,7 @@
     <ClCompile Include="Incubator.cpp">
       <Filter>Source Files\Building</Filter>
     </ClCompile>
-    <ClCompile Include="FactionResourcesManager.cpp">
-      <Filter>Source Files\Management</Filter>
-    </ClCompile>
-    <ClCompile Include="Resources.cpp">
+    <ClCompile Include="GameResources.cpp">
       <Filter>Source Files\Resources</Filter>
     </ClCompile>
     <ClCompile Include="Soldier.cpp">
@@ -71,6 +62,9 @@
     </ClCompile>
     <ClCompile Include="Worker.cpp">
       <Filter>Source Files\Unit</Filter>
+    </ClCompile>
+    <ClCompile Include="FactionResourcesManager.cpp">
+      <Filter>Source Files\Resources</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -86,10 +80,7 @@
     <ClInclude Include="Incubator.hpp">
       <Filter>Header Files\Building</Filter>
     </ClInclude>
-    <ClInclude Include="FactionResourcesManager.hpp">
-      <Filter>Header Files\Management</Filter>
-    </ClInclude>
-    <ClInclude Include="Resources.hpp">
+    <ClInclude Include="GameResources.hpp">
       <Filter>Header Files\Resources</Filter>
     </ClInclude>
     <ClInclude Include="Soldier.hpp">
@@ -97,6 +88,9 @@
     </ClInclude>
     <ClInclude Include="Worker.hpp">
       <Filter>Header Files\Unit</Filter>
+    </ClInclude>
+    <ClInclude Include="FactionResourcesManager.hpp">
+      <Filter>Header Files\Resources</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/StarCraft2/Worker.cpp
+++ b/StarCraft2/Worker.cpp
@@ -20,8 +20,8 @@ Barrack Worker::BuildBarrack()
 
 void Worker::CollectResources(FactionResourcesManager& frm)
 {
-    int resources = Resources::GetResourcesCollectedEachTime();
-    Resources::SubtractQuantity(resources);
+    int resources = GameResources::GetResourcesCollectedEachTime();
+    GameResources::SubtractQuantity(resources);
     frm.AddResources(resources);
     collectedResources += resources;
 }

--- a/StarCraft2/Worker.hpp
+++ b/StarCraft2/Worker.hpp
@@ -2,7 +2,7 @@
 #include <string>
 #include "Unit.hpp"
 #include "Barrack.hpp"
-#include "Resources.hpp"
+#include "GameResources.hpp"
 #include "FactionResourcesManager.hpp"
 class Incubator;
 


### PR DESCRIPTION
Renaming 'Resources' into 'GameResources' to make it clearer